### PR TITLE
Updated cakephp-utils to v3+ (task #3495)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "qobo/cakephp-utils": "^2.0"
+        "qobo/cakephp-utils": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",


### PR DESCRIPTION
Updated to [cakephp-utils v3+](https://github.com/QoboLtd/cakephp-utils/releases/tag/v3.0.0).