### PR TITLE
Update cakephp-utils to v4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "cakephp-plugin",
     "license": "GPL-2.0",
     "require": {
-        "qobo/cakephp-utils": "^3.0"
+        "qobo/cakephp-utils": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/Controller/Component/LanguageComponent.php
+++ b/src/Controller/Component/LanguageComponent.php
@@ -19,8 +19,10 @@ class LanguageComponent extends Component
     protected $rtl_languages = [];
 
     /**
-     *  initialize method
+     * Initialize method
      *
+     * @param array $config Options
+     * @return void
      */
     public function initialize(array $config)
     {

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -12,8 +12,9 @@ use Translations\Controller\Component\LanguageComponent;
 class LanguagesController extends AppController
 {
     /**
-     *  initialize method
+     * Initialize method
      *
+     * @return void
      */
     public function initialize()
     {
@@ -25,7 +26,7 @@ class LanguagesController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Network\Response|null
+     * @return void
      */
     public function index()
     {
@@ -38,9 +39,9 @@ class LanguagesController extends AppController
     /**
      * View method
      *
-     * @param string|null $id Language id.
-     * @return \Cake\Network\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @param string|null $id Language id.
+     * @return void
      */
     public function view($id = null)
     {

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -12,8 +12,9 @@ use Translations\Controller\Component\LanguageComponent;
 class TranslationsController extends AppController
 {
     /**
-     *  initialize method
+     * Initialize method
      *
+     * @return void
      */
     public function initialize()
     {
@@ -25,7 +26,7 @@ class TranslationsController extends AppController
     /**
      * Index method
      *
-     * @return \Cake\Network\Response|null
+     * @return void
      */
     public function index()
     {
@@ -59,9 +60,9 @@ class TranslationsController extends AppController
     /**
      * View method
      *
-     * @param string|null $id Translation id.
-     * @return \Cake\Network\Response|null
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @param string|null $id Translation id.
+     * @return void
      */
     public function view($id = null)
     {
@@ -77,7 +78,7 @@ class TranslationsController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Network\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Network\Response|null Redirects on successful add, renders view otherwise
      */
     public function add()
     {
@@ -99,8 +100,9 @@ class TranslationsController extends AppController
     }
 
     /**
-     *  Add or update method
-     * @return bool     when successfully added or updated returns true, false otherwise
+     * Add or update method
+     *
+     * @return void     When successfully added or updated prints in JSON true, false otherwise
      */
     public function addOrUpdate()
     {

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -130,13 +130,15 @@ class TranslationsTable extends Table
     }
 
     /**
-     *  addTranslation
-     *  adding a new translation for specified language and field
+     * addTranslation
+     *
+     * adding a new translation for specified language and field
      *
      * @param string $modelName          UUID record the translated field belongs to
      * @param string $recordId         translated field name
      * @param string $fieldName          language used for translation
-     * @param string $language    Translated text
+     * @param string $language    Language
+     * @param string $translatedText Translated text
      * @return bool                     true in case of successfully saved translation and false otherwise
      */
     public function addTranslation($modelName, $recordId, $fieldName, $language, $translatedText)


### PR DESCRIPTION
* Updated to [cakephp-utils v4+](https://github.com/QoboLtd/cakephp-utils/releases/tag/v4.0.0).
* Minor improvements to doc-blocks for PHPCS warnings