### PR TITLE
Event names enumeration (task #4352)

### DIFF
--- a/src/Controller/Api/AppController.php
+++ b/src/Controller/Api/AppController.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Utility\Hash;
 use Crud\Controller\ControllerTrait;
+use Translations\Event\EventName;
 
 class AppController extends Controller
 {
@@ -102,7 +103,7 @@ class AppController extends Controller
     public function index()
     {
         $this->Crud->on('beforePaginate', function (Event $event) {
-            $ev = new Event('Translations.Index.beforePaginate', $this, [
+            $ev = new Event((string)EventName::API_INDEX_BEFORE_PAGINATE(), $this, [
                 'query' => $event->subject()->query
             ]);
             $this->eventManager()->dispatch($ev);

--- a/src/Event/Controller/Api/IndexActionListener.php
+++ b/src/Event/Controller/Api/IndexActionListener.php
@@ -5,6 +5,7 @@ use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
+use Translations\Event\EventName;
 
 class IndexActionListener implements EventListenerInterface
 {
@@ -24,7 +25,7 @@ class IndexActionListener implements EventListenerInterface
     public function implementedEvents()
     {
         return [
-            'Translations.Index.beforePaginate' => 'beforePaginate',
+            (string)EventName::API_INDEX_BEFORE_PAGINATE() => 'beforePaginate',
         ];
     }
 

--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -1,0 +1,12 @@
+<?php
+namespace Translations\Event;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Event Name enum
+ */
+class EventName extends Enum
+{
+    const API_INDEX_BEFORE_PAGINATE = 'Translations.Index.beforePaginate';
+}


### PR DESCRIPTION
Use [php-enum](https://github.com/myclabs/php-enum) library to define event names enum. Modified all events to use `EventName` enumeration class.