### PR TITLE
Moving translations modal from the csv-migrations to event

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -3,7 +3,9 @@
 use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Translations\Event\Controller\Api\IndexActionListener;
+use Translations\Event\View\ViewActionListener;
 
 Configure::load('Translations.translations');
 
 EventManager::instance()->on(new IndexActionListener());
+EventManager::instance()->on(new ViewActionListener());

--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -9,4 +9,5 @@ use MyCLabs\Enum\Enum;
 class EventName extends Enum
 {
     const API_INDEX_BEFORE_PAGINATE = 'Translations.Index.beforePaginate';
+    const VIEW_BOTTOM = 'View.View.Body.Bottom';
 }

--- a/src/Event/View/ViewActionListener.php
+++ b/src/Event/View/ViewActionListener.php
@@ -1,0 +1,57 @@
+<?php
+namespace Translations\Event\View;
+
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Network\Request;
+use Cake\ORM\Query;
+use Cake\ORM\TableRegistry;
+use Translations\Event\EventName;
+
+class ViewActionListener implements EventListenerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function implementedEvents()
+    {
+        return [
+            (string)EventName::VIEW_BOTTOM() => 'getTranslationsModal',
+        ];
+    }
+
+    /**
+     * getTranslationsModal modal for fields translation
+     *
+     * @param \Cake\Event\Event $event from the view ctp
+     * @param mixed $request from the event broadcasted
+     * @param array $options that hold request object and options
+     *
+     * @return void
+     */
+    public function getTranslationsModal(Event $event, $request, array $options = [])
+    {
+        $appView = $event->subject();
+        $elementName = 'Translations.modal_add';
+
+        if (!$appView->elementExists($elementName)) {
+            return;
+        }
+
+        $modalBody = $appView->requestAction([
+            'plugin' => 'Translations',
+            'controller' => 'Translations',
+            'action' => 'add'
+        ], [
+            'query' => [
+                'embedded' => 'Translations',
+                'foreign_key' => 'object_foreign_key',
+                'modal_id' => 'translations_translate_id_modal',
+            ]
+        ]);
+
+        $content = $appView->element($elementName, ['modalBody' => $modalBody]);
+
+        $event->result .= $content;
+    }
+}

--- a/src/Template/Element/modal_add.ctp
+++ b/src/Template/Element/modal_add.ctp
@@ -1,0 +1,18 @@
+<?php
+    $modalBody = (!empty($modalBody) ? $modalBody : '');
+?>
+<div id="translations_translate_id_modal" class="modal fade" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                <h2 class="modal-title"><?= __('Manage Translations') ?></h2>
+            </div> <!-- modal-header -->
+            <div class="modal-body">
+                <?= $modalBody ?>
+            </div>
+        </div> <!-- modal-content -->
+    </div> <!-- modal-dialog -->
+</div> <!-- modal window -->


### PR DESCRIPTION
To keep rendered modal for translations under plugin's scope, we pass the modal via Event broadcasted from the application/other plugin, and attach the content to `$event-result`. 