### PR TITLE
Prefixing all table with 'qobo_translations' plugin prefix (task #5662)

### DIFF
--- a/config/Migrations/20180516093329_RenameLanguagesTable.php
+++ b/config/Migrations/20180516093329_RenameLanguagesTable.php
@@ -13,6 +13,6 @@ class RenameLanguagesTable extends AbstractMigration
     public function change()
     {
         $this->table('languages')
-            ->rename('qobo_languages');
+            ->rename('qobo_translations_languages');
     }
 }

--- a/config/Migrations/20180516093329_RenameLanguagesTable.php
+++ b/config/Migrations/20180516093329_RenameLanguagesTable.php
@@ -1,0 +1,18 @@
+<?php
+use Migrations\AbstractMigration;
+
+class RenameLanguagesTable extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('languages')
+            ->rename('qobo_languages');
+    }
+}

--- a/config/Migrations/20180516093550_PrefixTranslationsTable.php
+++ b/config/Migrations/20180516093550_PrefixTranslationsTable.php
@@ -1,0 +1,18 @@
+<?php
+use Migrations\AbstractMigration;
+
+class PrefixTranslationsTable extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('language_translations')
+            ->rename('qobo_language_translations');
+    }
+}

--- a/config/Migrations/20180516093550_PrefixTranslationsTable.php
+++ b/config/Migrations/20180516093550_PrefixTranslationsTable.php
@@ -13,6 +13,6 @@ class PrefixTranslationsTable extends AbstractMigration
     public function change()
     {
         $this->table('language_translations')
-            ->rename('qobo_language_translations');
+            ->rename('qobo_translations_translations');
     }
 }

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -36,7 +36,7 @@ class LanguagesTable extends Table
     {
         parent::initialize($config);
 
-        $this->setTable('qobo_languages');
+        $this->setTable('qobo_translations_languages');
         $this->setDisplayField('code');
         $this->setPrimaryKey('id');
 

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -36,7 +36,7 @@ class LanguagesTable extends Table
     {
         parent::initialize($config);
 
-        $this->setTable('languages');
+        $this->setTable('qobo_languages');
         $this->setDisplayField('code');
         $this->setPrimaryKey('id');
 

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -36,7 +36,7 @@ class TranslationsTable extends Table
     {
         parent::initialize($config);
 
-        $this->setTable('language_translations');
+        $this->setTable('qobo_language_translations');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
 

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -36,7 +36,7 @@ class TranslationsTable extends Table
     {
         parent::initialize($config);
 
-        $this->setTable('qobo_language_translations');
+        $this->setTable('qobo_translations_translations');
         $this->setDisplayField('id');
         $this->setPrimaryKey('id');
 

--- a/tests/Fixture/LanguageTranslationsFixture.php
+++ b/tests/Fixture/LanguageTranslationsFixture.php
@@ -9,6 +9,7 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class LanguageTranslationsFixture extends TestFixture
 {
+    public $table = 'qobo_language_translations';
     /**
      * Fields
      *

--- a/tests/Fixture/LanguageTranslationsFixture.php
+++ b/tests/Fixture/LanguageTranslationsFixture.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class LanguageTranslationsFixture extends TestFixture
 {
-    public $table = 'qobo_language_translations';
+    public $table = 'qobo_translations_translations';
     /**
      * Fields
      *

--- a/tests/Fixture/LanguagesFixture.php
+++ b/tests/Fixture/LanguagesFixture.php
@@ -9,6 +9,7 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class LanguagesFixture extends TestFixture
 {
+    public $table = 'qobo_languages';
 
     /**
      * Fields

--- a/tests/Fixture/LanguagesFixture.php
+++ b/tests/Fixture/LanguagesFixture.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class LanguagesFixture extends TestFixture
 {
-    public $table = 'qobo_languages';
+    public $table = 'qobo_translations_languages';
 
     /**
      * Fields


### PR DESCRIPTION
- Adding `qobo_translations` prefix for translation tables.