### PR TITLE
CakePHP 3.6 support and PHPStan (task #8244)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.twig]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+.htaccess text
+*.css text diff=css
+*.ctp text diff=php
+*.default text
+*.html text diff=html
+*.ini text
+*.js text
+*.md text
+*.php text diff=php
+*.po text
+*.properties text
+*.sql text
+*.svg text
+*.txt text
+*.xml text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+composer binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+
+# Web fonts are binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Treat zip files as binary
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,41 @@
+# Project specific files #
+##########################
 build/
 vendor/
+cghooks.lock
+
 composer.lock
 config/Migrations/schema-dump-default.lock
 config/Migrations/schema-dump-test.lock
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Tool specific files #
+#######################
+# vim
+*~
+*.swp
+*.swo
+# sublime text & textmate
+*.sublime-*
+*.stTheme.cache
+*.tmlanguage.cache
+*.tmPreferences.cache
+# Eclipse
+.settings/*
+# JetBrains, aka PHPStorm, IntelliJ IDEA
+.idea/*
+# NetBeans
+nbproject/*
+# Visual Studio Code
+.vscode
+# Sass preprocessor
+.sass-cache/

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    extensions: '.php,.ctp'
+    extensions: 'php,ctp'
+    exclude: 'Generic.Commenting.Todo'
 files:
-  ignore: ['config/*', 'tests/*']
+    ignore: ['webroot/plugins/*']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
-sudo: true
-dist: trusty
-
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - nightly
+dist: trusty
+
+sudo: false
 
 cache:
   directories:
@@ -21,25 +16,39 @@ env:
 
 matrix:
   fast_finish: true
+
   allow_failures:
+    - php: 7.3
     - php: nightly
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+    - php: 7.2
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: 7.3
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: nightly
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
 
 install:
   - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
-  - mkdir -p build/logs
+  - mkdir -p build/test-coverage build/test-results
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - vendor/bin/phpcs
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
+  - if [[ $PHPCS = 1 ]]; then ./vendor/bin/phpcs; fi
+  - if [[ $COVERAGE = 0 ]]; then ./vendor/bin/phpunit --no-coverage; fi
+  - if [[ $COVERAGE = 1 ]]; then ./vendor/bin/phpunit; fi
+  - if [[ $PHPSTAN = 1 ]]; then ./vendor/bin/phpstan analyse; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh
   - chmod +x /tmp/codecov.sh
-  - /tmp/codecov.sh -s build/logs
+  - /tmp/codecov.sh -s build/test-results
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
 
   include:
     - php: 7.1
-      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=1
     - php: 7.2
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: 7.3
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: nightly
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -1,32 +1,60 @@
 {
     "name": "qobo/cakephp-translations",
     "description": "Languages and translations plugin for CakePHP",
+    "keywords": ["cakephp", "translactions", "languages", "i18n"],
     "type": "cakephp-plugin",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Qobo Ltd",
-			"email": "info@qobo.biz",
-			"homepage": "https://www.qobo.biz",
-			"role": "Developer"
-		}
-	],
+    "license": "MIT",
+    "homepage": "https://www.qobo.biz",
+    "authors": [
+        {
+            "name": "Qobo Ltd",
+            "email": "support@qobo.biz",
+            "homepage": "https://www.qobo.biz",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/QoboLtd/cakephp-translations/issues",
+        "source": "https://github.com/QoboLtd/cakephp-translations"
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "7.1"
+        }
+    },
     "require": {
-        "qobo/cakephp-utils": "^9.0"
+        "qobo/cakephp-utils": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "qobo/cakephp-composer-dev": "^v1.0"
     },
     "autoload": {
         "psr-4": {
-            "Translations\\": "src"
+            "Translations\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Translations\\Test\\": "tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "Translations\\Test\\": "tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
-    }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "prefer-stable": true
 }

--- a/config/translations.php
+++ b/config/translations.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 return [
     'Translations' => [

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,16 +9,15 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
-
-    <!-- Extensions to check -->
-    <arg name="extensions" value="php,inc,ctp,js,css" />
 
     <!-- Use colors -->
     <arg name="colors" />
@@ -29,5 +28,12 @@
     <!-- Files and directories to check -->
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./config/</file>
     <file>./webroot/</file>
+
+    <!-- Ignore files -->
+    <arg name="ignore" value="config/Migrations/" />
+
+    <!-- Ignore minified files -->
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests
+        - webroot
+    autoload_files:
+        - tests/bootstrap.php
+    earlyTerminatingMethodCalls:
+        Cake\Console\Shell:
+            - abort
+includes:
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/timeweb/phpstan-enum/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
     verbose="true"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
-
-	<filter>
-		<whitelist>
-            <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./webroot/</directory>
-		</whitelist>
-	</filter>
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
     <logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/test-coverage"/>
+        <log type="coverage-clover" target="build/test-results/clover.xml"/>
+        <log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+        <log type="junit" target="build/test-results/junit.xml"/>
     </logging>
+
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="plugin">
+            <directory>tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -38,11 +37,11 @@
         </listener>
     </listeners>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="Plugin Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -23,7 +23,7 @@ class LanguagesController extends AppController
     /**
      * Index method
      *
-     * @return void
+     * @return \Cake\Http\Response|void
      */
     public function index()
     {
@@ -35,7 +35,7 @@ class LanguagesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -58,10 +58,10 @@ class LanguagesController extends AppController
      * Delete method
      *
      * @param string|null $id Language id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return \Cake\Http\Response|void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
         $language = $this->Languages->get($id);

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -35,7 +35,7 @@ class LanguagesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -43,11 +43,11 @@ class LanguagesController extends AppController
         if ($this->request->is('post')) {
             $languageEntity = $this->Languages->addOrRestore($this->request->getData());
             if (!empty($languageEntity)) {
-                $this->Flash->success(__('The language has been saved.'));
+                $this->Flash->success((string)__('The language has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The language could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The language could not be saved. Please, try again.'));
         }
         $languages = $this->Languages->getAvailable();
         $this->set(compact('language', 'languages'));
@@ -58,7 +58,7 @@ class LanguagesController extends AppController
      * Delete method
      *
      * @param string|null $id Language id.
-     * @return \Cake\Http\Response|void Redirects to index.
+     * @return \Cake\Http\Response|void|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete(string $id = null)
@@ -66,9 +66,9 @@ class LanguagesController extends AppController
         $this->request->allowMethod(['post', 'delete']);
         $language = $this->Languages->get($id);
         if ($this->Languages->delete($language)) {
-            $this->Flash->success(__('The language has been deleted.'));
+            $this->Flash->success((string)__('The language has been deleted.'));
         } else {
-            $this->Flash->error(__('The language could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The language could not be deleted. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'index']);

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -35,7 +35,7 @@ class LanguagesController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Network\Response|null Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
      */
     public function add()
     {
@@ -58,7 +58,7 @@ class LanguagesController extends AppController
      * Delete method
      *
      * @param string|null $id Language id.
-     * @return \Cake\Network\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)

--- a/src/Controller/LanguagesController.php
+++ b/src/Controller/LanguagesController.php
@@ -41,7 +41,8 @@ class LanguagesController extends AppController
     {
         $language = $this->Languages->newEntity();
         if ($this->request->is('post')) {
-            $languageEntity = $this->Languages->addOrRestore($this->request->getData());
+            $data = is_array($this->request->getData()) ? $this->request->getData() : [];
+            $languageEntity = $this->Languages->addOrRestore($data);
             if (!empty($languageEntity)) {
                 $this->Flash->success((string)__('The language has been saved.'));
 

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -75,7 +75,8 @@ class TranslationsController extends AppController
     {
         $translation = $this->Translations->newEntity();
         if ($this->request->is('post')) {
-            $translation = $this->Translations->patchEntity($translation, $this->request->getData());
+            $data = is_array($this->request->getData()) ? $this->request->getData() : [];
+            $translation = $this->Translations->patchEntity($translation, $data);
             $result = $this->Translations->save($translation);
             if ($result) {
                 $this->Flash->success((string)__('The translation has been saved.'));
@@ -100,7 +101,10 @@ class TranslationsController extends AppController
         if (!$this->request->is('ajax')) {
             throw new \RuntimeException('Wrong type of request!');
         }
-        $params = $this->request->getData();
+        $params = is_array($this->request->getData()) ? $this->request->getData() : [];
+        /**
+         * @var \Cake\Datasource\EntityInterface $translation
+         */
         $translation = $this->Translations->getTranslations(
             $params['object_model'],
             $params['object_foreign_key'],
@@ -111,6 +115,9 @@ class TranslationsController extends AppController
             ]
         );
         if (empty($translation)) {
+            /**
+             * @var \Cake\Datasource\EntityInterface $translation
+             */
             $translation = $this->Translations->newEntity();
         }
 
@@ -134,7 +141,8 @@ class TranslationsController extends AppController
             'contain' => ['Languages']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $translation = $this->Translations->patchEntity($translation, $this->request->getData());
+            $data = is_array($this->request->getData()) ? $this->request->getData() : [];
+            $translation = $this->Translations->patchEntity($translation, $data);
             if ($this->Translations->save($translation)) {
                 $this->Flash->success((string)__('The translation has been saved.'));
 

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -69,7 +69,7 @@ class TranslationsController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise
+     * @return \Cake\Http\Response|void|null Redirects on successful add, renders view otherwise
      */
     public function add()
     {
@@ -78,11 +78,11 @@ class TranslationsController extends AppController
             $translation = $this->Translations->patchEntity($translation, $this->request->getData());
             $result = $this->Translations->save($translation);
             if ($result) {
-                $this->Flash->success(__('The translation has been saved.'));
+                $this->Flash->success((string)__('The translation has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The translation could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The translation could not be saved. Please, try again.'));
         }
         $languages = $this->Translations->Languages->find('all', ['limit' => 200]);
         $this->set(compact('translation', 'languages'));
@@ -125,7 +125,7 @@ class TranslationsController extends AppController
      * Edit method
      *
      * @param string|null $id Translation id.
-     * @return \Cake\Http\Response|void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
     public function edit(string $id = null)
@@ -136,11 +136,11 @@ class TranslationsController extends AppController
         if ($this->request->is(['patch', 'post', 'put'])) {
             $translation = $this->Translations->patchEntity($translation, $this->request->getData());
             if ($this->Translations->save($translation)) {
-                $this->Flash->success(__('The translation has been saved.'));
+                $this->Flash->success((string)__('The translation has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The translation could not be saved. Please, try again.'));
+            $this->Flash->error((string)__('The translation could not be saved. Please, try again.'));
         }
         $languages = $this->Translations->Languages->find('list', ['limit' => 200]);
         $this->set(compact('translation', 'languages'));
@@ -151,7 +151,7 @@ class TranslationsController extends AppController
      * Delete method
      *
      * @param string|null $id Translation id.
-     * @return \Cake\Http\Response|void Redirects to index.
+     * @return \Cake\Http\Response|void|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete(string $id = null)
@@ -159,9 +159,9 @@ class TranslationsController extends AppController
         $this->request->allowMethod(['post', 'delete']);
         $translation = $this->Translations->get($id);
         if ($this->Translations->delete($translation)) {
-            $this->Flash->success(__('The translation has been deleted.'));
+            $this->Flash->success((string)__('The translation has been deleted.'));
         } else {
-            $this->Flash->error(__('The translation could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The translation could not be deleted. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'index']);

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -23,7 +23,7 @@ class TranslationsController extends AppController
     /**
      * Index method
      *
-     * @return void
+     * @return \Cake\Http\Response|void
      */
     public function index()
     {
@@ -54,9 +54,9 @@ class TranslationsController extends AppController
      *
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      * @param string|null $id Translation id.
-     * @return void
+     * @return \Cake\Http\Response|void
      */
-    public function view($id = null)
+    public function view(string $id = null)
     {
         $translation = $this->Translations->get($id, [
             'contain' => ['Languages']
@@ -69,7 +69,7 @@ class TranslationsController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise
+     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise
      */
     public function add()
     {
@@ -92,7 +92,7 @@ class TranslationsController extends AppController
     /**
      * Add or update method
      *
-     * @return void     When successfully added or updated prints in JSON true, false otherwise
+     * @return \Cake\Http\Response|void     When successfully added or updated prints in JSON true, false otherwise
      */
     public function addOrUpdate()
     {
@@ -125,10 +125,10 @@ class TranslationsController extends AppController
      * Edit method
      *
      * @param string|null $id Translation id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function edit($id = null)
+    public function edit(string $id = null)
     {
         $translation = $this->Translations->get($id, [
             'contain' => ['Languages']
@@ -151,10 +151,10 @@ class TranslationsController extends AppController
      * Delete method
      *
      * @param string|null $id Translation id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return \Cake\Http\Response|void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete($id = null)
+    public function delete(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
         $translation = $this->Translations->get($id);

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -69,7 +69,7 @@ class TranslationsController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Network\Response|null Redirects on successful add, renders view otherwise
+     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise
      */
     public function add()
     {
@@ -125,8 +125,8 @@ class TranslationsController extends AppController
      * Edit method
      *
      * @param string|null $id Translation id.
-     * @return \Cake\Network\Response|null Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Network\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
     public function edit($id = null)
     {
@@ -151,7 +151,7 @@ class TranslationsController extends AppController
      * Delete method
      *
      * @param string|null $id Translation id.
-     * @return \Cake\Network\Response|null Redirects to index.
+     * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
     public function delete($id = null)

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -39,7 +39,7 @@ class TranslationsController extends AppController
                     'field' => !empty($params['object_field']) ? $params['object_field'] : '',
                 ]
             );
-            $this->response->type('application/json');
+            $this->response->withType('application/json');
             $this->autoRender = false;
             echo json_encode($translations, JSON_UNESCAPED_UNICODE);
         } else {
@@ -116,7 +116,7 @@ class TranslationsController extends AppController
 
         $translation = $this->Translations->patchEntity($translation, $params);
         $result = $this->Translations->save($translation);
-        $this->response->type('application/json');
+        $this->response->withType('application/json');
         $this->autoRender = false;
         echo json_encode(!empty($result) ? true : false);
     }

--- a/src/Model/Entity/Language.php
+++ b/src/Model/Entity/Language.php
@@ -17,11 +17,13 @@ use Cake\ORM\Entity;
  * Language Entity
  *
  * @property string $id
+ * @property string $name
  * @property string $code
  * @property boolean $is_active
  * @property boolean $is_rtl
  * @property \Cake\I18n\Time $created
  * @property \Cake\I18n\Time $modified
+ * @property \Cake\I18n\Time $trashed
  *
  * @property \Translations\Model\Entity\Translation[] $translations
  */

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -93,10 +93,10 @@ class LanguagesTable extends Table
      * @param string $locale Locale string (example: ru_RU.KOI8-R)
      * @return string Language (example: ru)
      */
-    public function localeToLanguage($locale)
+    public function localeToLanguage(string $locale): string
     {
-        if (!is_string($locale)) {
-            throw new InvalidArgumentException("Locale must be string. " . gettype($locale) . " given.");
+        if (empty($locale)) {
+            throw new InvalidArgumentException("Locale must be a non-emptystring.");
         }
 
         // Truncate all, starting with underscore, at, or dot
@@ -110,9 +110,9 @@ class LanguagesTable extends Table
     /**
      * Get a list of all right-to-left language codes
      *
-     * @return array
+     * @return mixed[]
      */
-    public function getRtl()
+    public function getRtl(): array
     {
         $result = (array)Configure::read('Translations.rtl_languages');
 
@@ -125,7 +125,7 @@ class LanguagesTable extends Table
      * @param string $language Language code or locale string (example: ru_RU.KOI8-R)
      * @return bool
      */
-    public function isRtl($language)
+    public function isRtl(string $language): bool
     {
         $result = false;
 
@@ -141,9 +141,9 @@ class LanguagesTable extends Table
     /**
      * Get a list of supported language codes and labels
      *
-     * @return array
+     * @return mixed[]
      */
-    public function getSupported()
+    public function getSupported(): array
     {
         $result = (array)Configure::read('Translations.languages');
 
@@ -157,9 +157,9 @@ class LanguagesTable extends Table
      * configuration, but haven't yet been used for
      * an active language.
      *
-     * @return array
+     * @return mixed[]
      */
-    public function getAvailable()
+    public function getAvailable(): array
     {
         $result = [];
 
@@ -179,12 +179,12 @@ class LanguagesTable extends Table
      * @param string $code Language code to lookup
      * @return string
      */
-    public function getName($code)
+    public function getName(string $code): string
     {
         $result = $code;
 
-        if (!is_string($code)) {
-            throw new InvalidArgumentException("Code must be string. " . gettype($code) . " given.");
+        if (empty($code)) {
+            throw new InvalidArgumentException("Code must be a non-empty string.");
         }
 
         $languages = $this->getSupported();
@@ -198,10 +198,11 @@ class LanguagesTable extends Table
     /**
      * Add a new language or restore a deleted one
      *
-     * @param array $data Language data to populate Entity with
-     * @return \Cake\ORM\Entity
+     * @throws \InvalidArgumentException when data is wrong or incomplete
+     * @param mixed[] $data Language data to populate Entity with
+     * @return \Translations\Model\Entity\Language
      */
-    public function addOrRestore(array $data)
+    public function addOrRestore(array $data): \Translations\Model\Entity\Language
     {
         if (empty($data['code'])) {
             throw new InvalidArgumentException("Language data is missing 'code' key");
@@ -225,6 +226,9 @@ class LanguagesTable extends Table
 
         $newEntity = $this->newEntity();
         $newEntity = $this->patchEntity($newEntity, $data);
+        /**
+         * @var \Translations\Model\Entity\Language $result
+         */
         $result = $this->save($newEntity);
 
         return $result;

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -100,7 +100,7 @@ class LanguagesTable extends Table
         }
 
         // Truncate all, starting with underscore, at, or dot
-        $result = preg_replace('/(_|@|\.).*$/', '', strtolower($locale));
+        $result = (string)preg_replace('/(_|@|\.).*$/', '', strtolower($locale));
         // Convert to lowercase for consistency
         $result = strtolower($result);
 

--- a/src/Model/Table/LanguagesTable.php
+++ b/src/Model/Table/LanguagesTable.php
@@ -22,6 +22,7 @@ use InvalidArgumentException;
  * Languages Model
  *
  * @property \Cake\ORM\Association\HasMany $Translations
+ * @method restoreTrash(\Cake\Datasource\EntityInterface $entity = null, array $options)
  *
  */
 class LanguagesTable extends Table
@@ -216,6 +217,9 @@ class LanguagesTable extends Table
             $data['name'] = $this->getName($data['code']);
         }
 
+        /**
+         * @var \Cake\Datasource\EntityInterface $deletedEntity
+         */
         $deletedEntity = $this->find('onlyTrashed')
             ->where(['code' => $data['code']])
             ->first();

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -15,6 +15,7 @@ use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
+use InvalidArgumentException;
 
 /**
  * Translations Model
@@ -177,16 +178,21 @@ class TranslationsTable extends Table
     /**
      *  Retrive language ID by code
      *
+     * @throws \InvalidArgumentException for unknown short code
      * @param string $shortCode     language code i.e. ru, cn etc
-     * @return string|null          language's uuid
+     * @return string              language's uuid
      */
-    public function getLanguageId(string $shortCode): ?string
+    public function getLanguageId(string $shortCode): string
     {
         $query = $this->Languages->find('all', [
             'conditions' => ['Languages.code' => $shortCode]
         ]);
         $language = $query->first();
 
-        return !empty($language->id) ? $language->id : null;
+        if (empty($language->id)) {
+            throw new InvalidArgumentException("Unsupported language code [$shortCode]");
+        }
+
+        return $language->id;
     }
 }

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -138,7 +138,7 @@ class TranslationsTable extends Table
 
             return $entity;
         } else {
-            $query->hydrate(false);
+            $query->enableHydration(false);
 
             return $query->toList();
         }

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -102,10 +102,10 @@ class TranslationsTable extends Table
      *
      * @param string $modelName     model name
      * @param string $recordId      uuid of record the translated field belogns to
-     * @param string $options       ID of the language used for translation
-     * @return array                list of saved translations
+     * @param mixed[] $options      ID of the language used for translation
+     * @return mixed[]              list of saved translations
      */
-    public function getTranslations($modelName, $recordId, $options = [])
+    public function getTranslations(string $modelName, string $recordId, array $options = []): array
     {
         $conditions = [
             'object_model' => $modelName,
@@ -151,8 +151,11 @@ class TranslationsTable extends Table
      * @param string $translatedText Translated text
      * @return bool                     true in case of successfully saved translation and false otherwise
      */
-    public function addTranslation($modelName, $recordId, $fieldName, $language, $translatedText)
+    public function addTranslation(string $modelName, string $recordId, string $fieldName, string $language, string $translatedText): bool
     {
+        /**
+         * @var \Translations\Model\Entity\Translation $translationEntity
+         */
         $translationEntity = $this->newEntity();
 
         $translationEntity->object_model = $modelName;
@@ -170,9 +173,9 @@ class TranslationsTable extends Table
      *  Retrive language ID by code
      *
      * @param string $shortCode     language code i.e. ru, cn etc
-     * @return string               language's uuid
+     * @return string|null          language's uuid
      */
-    public function getLanguageId($shortCode)
+    public function getLanguageId(string $shortCode): ?string
     {
         $query = $this->Languages->find('all', [
             'conditions' => ['Languages.code' => $shortCode]

--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -103,9 +103,9 @@ class TranslationsTable extends Table
      * @param string $modelName     model name
      * @param string $recordId      uuid of record the translated field belogns to
      * @param mixed[] $options      ID of the language used for translation
-     * @return mixed[]              list of saved translations
+     * @return \Translations\Model\Entity\Translation|array|null single record or list of saved translations
      */
-    public function getTranslations(string $modelName, string $recordId, array $options = []): array
+    public function getTranslations(string $modelName, string $recordId, array $options = [])
     {
         $conditions = [
             'object_model' => $modelName,
@@ -131,7 +131,12 @@ class TranslationsTable extends Table
             ],
         ]);
         if (!empty($options['toEntity'])) {
-            return $query->first();
+            /**
+             * @var \Translations\Model\Entity\Translation $entity
+             */
+            $entity = $query->first();
+
+            return $entity;
         } else {
             $query->hydrate(false);
 

--- a/src/Template/Languages/add.ctp
+++ b/src/Template/Languages/add.ctp
@@ -41,7 +41,7 @@ echo $this->Html->script(
                 <div class="box-body">
                     <div class="row">
                         <div class="col-xs-12">
-                            <?= $this->Form->input('code', [
+                            <?= $this->Form->control('code', [
                                 'options' => $languages,
                                 'type' => 'select',
                                 'class' => 'select2',

--- a/src/Template/Translations/add.ctp
+++ b/src/Template/Translations/add.ctp
@@ -13,7 +13,7 @@
 <section class="content">
     <div class="row">
         <div class="col-xs-12">
-            <?= $this->Form->input('orig_for_translate', ['type' => 'textarea', 'label' => 'English', 'id' => 'orig_for_translate', 'required' => false, 'disabled' => true]); ?>
+            <?= $this->Form->control('orig_for_translate', ['type' => 'textarea', 'label' => 'English', 'id' => 'orig_for_translate', 'required' => false, 'disabled' => true]); ?>
         </div>
     </div>
     <hr/>
@@ -29,7 +29,7 @@
             echo $this->Form->hidden('code', ['value' => $language->code]);
         ?>
         <div class="col-xs-12 col-md-12">
-            <?= $this->Form->input('translation', ['label' => $language->name, 'placeholder' => 'Translation', 'id' => 'translation_' . $language->code, 'required' => false]); ?>
+            <?= $this->Form->control('translation', ['label' => $language->name, 'placeholder' => 'Translation', 'id' => 'translation_' . $language->code, 'required' => false]); ?>
         </div>
     </div>
     <div class="row">

--- a/src/Template/Translations/edit.ctp
+++ b/src/Template/Translations/edit.ctp
@@ -31,7 +31,7 @@
                             </dl>
                         </div>
                         <div class="col-md-8">
-                            <?= $this->Form->input('translation'); ?>
+                            <?= $this->Form->control('translation'); ?>
                         </div>
                     </div>
                 </div>

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Translations\Test\App;
+
+use Cake\Core\Configure;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(ErrorHandlerMiddleware::class)
+
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(AssetMiddleware::class)
+
+            // Add routing middleware.
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -5,5 +5,17 @@ use \Cake\Controller\Controller;
 
 class AppController extends Controller
 {
-    public $components = ['Auth', 'Flash', 'RequestHandler'];
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Auth', [
+            'authenticate' => ['Form']
+        ]);
+
+        $this->loadComponent('Flash');
+        $this->loadComponent('RequestHandler', [
+            'enableBeforeRedirect' => false,
+        ]);
+    }
+
 }

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -17,5 +17,4 @@ class AppController extends Controller
             'enableBeforeRedirect' => false,
         ]);
     }
-
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,14 +1,16 @@
 <?php
 namespace Translations\Test\App\Controller;
 
-use \Cake\Controller\Controller;
+use Cake\Controller\Controller;
 
 class UsersController extends Controller
 {
     /**
      * Simple users login action
+     *
+     * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/TestCase/Controller/LanguagesControllerTest.php
+++ b/tests/TestCase/Controller/LanguagesControllerTest.php
@@ -8,6 +8,8 @@ use Translations\Controller\LanguagesController;
 
 /**
  * Translations\Controller\LanguagesController Test Case
+ *
+ * @property \Translations\Model\Table\LanguagesTable $Languages
  */
 class LanguagesControllerTest extends IntegrationTestCase
 {
@@ -41,19 +43,19 @@ class LanguagesControllerTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->get('/language-translations/languages');
         $this->assertResponseOk();
     }
 
-    public function testAddGet()
+    public function testAddGet(): void
     {
         $this->get('/language-translations/languages/add');
         $this->assertResponseOk();
     }
 
-    public function testAddPost()
+    public function testAddPost(): void
     {
         $data = ['code' => 'el_CY'];
         $this->post('/language-translations/languages/add', $data);
@@ -63,10 +65,14 @@ class LanguagesControllerTest extends IntegrationTestCase
 
         $this->assertFalse($query->isEmpty());
         $this->assertEquals(1, $query->count());
-        $this->assertEquals('Greek (Cyprus)', $query->first()->get('name'));
+        /**
+         * @var \Translations\Model\Entity\Language $first
+         */
+        $first = $query->first();
+        $this->assertEquals('Greek (Cyprus)', $first->get('name'));
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $this->post('/language-translations/languages/delete/00000000-0000-0000-0000-000000000001', []);
         $this->assertRedirect(['controller' => 'Languages', 'action' => 'index']);

--- a/tests/TestCase/Controller/LanguagesControllerTest.php
+++ b/tests/TestCase/Controller/LanguagesControllerTest.php
@@ -21,7 +21,11 @@ class LanguagesControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Languages = TableRegistry::get('Translations.Languages');
+        /**
+         * @var \Translations\Model\Table\LanguagesTable $table
+         */
+        $table = TableRegistry::get('Translations.Languages');
+        $this->Languages = $table;
 
         // Run all tests as authenticated user
         $this->session([

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -21,7 +21,11 @@ class TranslationsControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->Translations = TableRegistry::get('Translations.Translations');
+        /**
+         * @var \Translations\Model\Table\TranslationsTable $table
+         */
+        $table = TableRegistry::get('Translations.Translations');
+        $this->Translations = $table;
 
         // Run all tests as authenticated user
         $this->session([

--- a/tests/TestCase/Controller/TranslationsControllerTest.php
+++ b/tests/TestCase/Controller/TranslationsControllerTest.php
@@ -7,6 +7,8 @@ use Cake\TestSuite\IntegrationTestCase;
 
 /**
  * Translations\Controller\TranslationsController Test Case
+ *
+ * @property \Translations\Model\Table\TranslationsTable $Translations
  */
 class TranslationsControllerTest extends IntegrationTestCase
 {
@@ -43,25 +45,25 @@ class TranslationsControllerTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $this->get('/language-translations/translations');
         $this->assertResponseOk();
     }
 
-    public function testIndexJson()
+    public function testIndexJson(): void
     {
         $this->get('/language-translations/translations?json=1&object_model=Leads&object_foreign_key=00000000-0000-0000-0000-100000000001');
         $this->assertResponseOk();
     }
 
-    public function testView()
+    public function testView(): void
     {
         $this->get('/language-translations/translations/view/00000000-0000-0000-0000-000000000001');
         $this->assertResponseOk();
     }
 
-    public function testAdd()
+    public function testAdd(): void
     {
         $expected = 1 + $this->Translations->find('all')->count();
 
@@ -85,7 +87,7 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->Translations->find('all')->count());
     }
 
-    public function testAddMissingData()
+    public function testAddMissingData(): void
     {
         $expected = $this->Translations->find('all')->count();
 
@@ -104,7 +106,7 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertSession('The translation could not be saved. Please, try again.', 'Flash.flash.0.message');
     }
 
-    public function testAddInvalidData()
+    public function testAddInvalidData(): void
     {
         $expected = $this->Translations->find('all')->count();
 
@@ -124,7 +126,7 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertSession('The translation could not be saved. Please, try again.', 'Flash.flash.0.message');
     }
 
-    public function testAddNoData()
+    public function testAddNoData(): void
     {
         $expected = $this->Translations->find('all')->count();
         $this->post('/language-translations/translations/add');
@@ -134,13 +136,13 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertSession('The translation could not be saved. Please, try again.', 'Flash.flash.0.message');
     }
 
-    public function testAddGet()
+    public function testAddGet(): void
     {
         $this->get('/language-translations/translations/add');
         $this->assertResponseOk();
     }
 
-    public function testAddOrUpdate()
+    public function testAddOrUpdate(): void
     {
         $this->configRequest([
             'headers' => [
@@ -162,14 +164,14 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertResponseOk();
     }
 
-    public function testAddOrUpdateNonAjax()
+    public function testAddOrUpdateNonAjax(): void
     {
         $this->post('/language-translations/translations/add-or-update');
 
         $this->assertResponseFailure();
     }
 
-    public function testEdit()
+    public function testEdit(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -190,13 +192,13 @@ class TranslationsControllerTest extends IntegrationTestCase
         $this->assertEquals($data['translation'], $entity->get('translation'));
     }
 
-    public function testEditGet()
+    public function testEditGet(): void
     {
         $this->get('/language-translations/translations/edit/00000000-0000-0000-0000-000000000001');
         $this->assertResponseOk();
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $this->post('/language-translations/translations/delete/00000000-0000-0000-0000-000000000001', []);
         $this->assertRedirect(['controller' => 'Translations', 'action' => 'index']);

--- a/tests/TestCase/Model/Table/LanguagesTableTest.php
+++ b/tests/TestCase/Model/Table/LanguagesTableTest.php
@@ -40,7 +40,11 @@ class LanguagesTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('Languages') ? [] : ['className' => 'Translations\Model\Table\LanguagesTable'];
-        $this->Languages = TableRegistry::get('Languages', $config);
+        /**
+         * @var \Translations\Model\Table\LanguagesTable $table
+         */
+        $table = TableRegistry::get('Languages', $config);
+        $this->Languages = $table;
 
         // Load default plugin configuration
         Configure::load('Translations.translations');

--- a/tests/TestCase/Model/Table/LanguagesTableTest.php
+++ b/tests/TestCase/Model/Table/LanguagesTableTest.php
@@ -63,7 +63,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->assertInstanceOf(LanguagesTable::class, $this->Languages);
     }
@@ -73,7 +73,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $validator = new Validator();
         $result = $this->Languages->validationDefault($validator);
@@ -86,7 +86,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildRules()
+    public function testBuildRules(): void
     {
         $rulesChecker = new RulesChecker();
         $result = $this->Languages->buildRules($rulesChecker);
@@ -99,7 +99,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testGetRtl()
+    public function testGetRtl(): void
     {
         $result = $this->Languages->getRtl();
         $this->assertTrue(is_array($result), 'getRtl() returned a non-array result');
@@ -119,9 +119,9 @@ class LanguagesTableTest extends TestCase
     /**
      * Locale/Langauge Provider
      *
-     * @return array
+     * @return mixed[]
      */
-    public function localeLanguageProvider()
+    public function localeLanguageProvider(): array
     {
         return [
             ['ru', 'ru'],
@@ -139,7 +139,7 @@ class LanguagesTableTest extends TestCase
      * @param string $expected Expected language
      * @return void
      */
-    public function testLocaleToLanguage($locale, $expected)
+    public function testLocaleToLanguage(string $locale, string $expected): void
     {
         $actual = $this->Languages->localeToLanguage($locale);
         $this->assertTrue(is_string($actual), 'localeToLanguage() returned a non-string result');
@@ -152,18 +152,18 @@ class LanguagesTableTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @return void
      */
-    public function testLocaleToLanguageException()
+    public function testLocaleToLanguageException(): void
     {
-        // Send a non-string parameter
-        $result = $this->Languages->localeToLanguage(['ru']);
+        // Send an empty string parameter
+        $result = $this->Languages->localeToLanguage('');
     }
 
     /**
      * Langauge/RTL Provider
      *
-     * @return array
+     * @return mixed[]
      */
-    public function languageRtlProvider()
+    public function languageRtlProvider(): array
     {
         return [
             ['ar', true],
@@ -184,7 +184,7 @@ class LanguagesTableTest extends TestCase
      * @param bool $expected Expected result
      * @return void
      */
-    public function testIsRtl($language, $expected)
+    public function testIsRtl(string $language, bool $expected): void
     {
         $actual = $this->Languages->isRtl($language);
         $this->assertTrue(is_bool($actual), 'isRtl() returned a non-boolean result');
@@ -196,7 +196,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testGetSupported()
+    public function testGetSupported(): void
     {
         $result = $this->Languages->getSupported();
         $this->assertTrue(is_array($result), 'getSupported() returned a non-array result');
@@ -228,7 +228,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testGetAvailable()
+    public function testGetAvailable(): void
     {
         $result = $this->Languages->getAvailable();
         $this->assertTrue(is_array($result), 'getAvailable() returned a non-array result');
@@ -266,7 +266,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $result = $this->Languages->getName('zh');
         $this->assertTrue(is_string($result), 'getName() returned a non-string result');
@@ -279,10 +279,10 @@ class LanguagesTableTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @return void
      */
-    public function testGetNameException()
+    public function testGetNameException(): void
     {
-        // Send a non-string parameter
-        $result = $this->Languages->getName(['ru']);
+        // Send an empty string parameter
+        $result = $this->Languages->getName('');
     }
 
     /**
@@ -291,7 +291,7 @@ class LanguagesTableTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @return void
      */
-    public function testAddOrRestoreException()
+    public function testAddOrRestoreException(): void
     {
         // Send an empty array.  Anything without 'code' key.
         $result = $this->Languages->addOrRestore([]);
@@ -302,7 +302,7 @@ class LanguagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testAddOrRestore()
+    public function testAddOrRestore(): void
     {
         // Add Thai
         $result = $this->Languages->addOrRestore(['code' => 'th']);

--- a/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -40,7 +40,11 @@ class TranslationsTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::exists('Translations') ? [] : ['className' => 'Translations\Model\Table\TranslationsTable'];
-        $this->Translations = TableRegistry::get('Translations', $config);
+        /**
+         * @var \Translations\Model\Table\TranslationsTable $table
+         */
+        $table = TableRegistry::get('Translations', $config);
+        $this->Translations = $table;
     }
 
     /**
@@ -66,8 +70,10 @@ class TranslationsTableTest extends TestCase
         $result = $this->Translations->getTranslations($modelName, $recordId);
 
         $this->assertInternalType('array', $result);
-        $this->assertEquals(3, count($result));
-        $this->assertEquals($result[0]['object_model'], 'Leads');
+        if (is_array($result)) {
+            $this->assertEquals(3, count($result));
+            $this->assertEquals($result[0]['object_model'], 'Leads');
+        }
     }
 
     public function testGetTranslationsWithLanguageId(): void
@@ -79,8 +85,10 @@ class TranslationsTableTest extends TestCase
         $result = $this->Translations->getTranslations($modelName, $recordId, [
             'language' => $languageId,
         ]);
-
-        $this->assertEquals(2, count($result));
+        $this->assertTrue(is_array($result), "getTranslations() returned a non-array result");
+        if (is_array($result)) {
+            $this->assertEquals(2, count($result));
+        }
     }
 
     public function testGetTranslationsWithObjectField(): void
@@ -92,8 +100,10 @@ class TranslationsTableTest extends TestCase
         $result = $this->Translations->getTranslations($modelName, $recordId, [
             'field' => $objectField,
         ]);
-
-        $this->assertEquals(2, count($result));
+        $this->assertTrue(is_array($result), "getTranslations() returned a non-array result");
+        if (is_array($result)) {
+            $this->assertEquals(2, count($result));
+        }
     }
 
     public function testGetTranslationsAsEntity(): void

--- a/tests/TestCase/Model/Table/TranslationsTableTest.php
+++ b/tests/TestCase/Model/Table/TranslationsTableTest.php
@@ -58,7 +58,7 @@ class TranslationsTableTest extends TestCase
     /**
      *  testGetTranslations method
      */
-    public function testGetTranslations()
+    public function testGetTranslations(): void
     {
         $modelName = 'Leads';
         $recordId = '00000000-0000-0000-0000-100000000001';
@@ -70,7 +70,7 @@ class TranslationsTableTest extends TestCase
         $this->assertEquals($result[0]['object_model'], 'Leads');
     }
 
-    public function testGetTranslationsWithLanguageId()
+    public function testGetTranslationsWithLanguageId(): void
     {
         $modelName = 'Leads';
         $recordId = '00000000-0000-0000-0000-100000000001';
@@ -83,7 +83,7 @@ class TranslationsTableTest extends TestCase
         $this->assertEquals(2, count($result));
     }
 
-    public function testGetTranslationsWithObjectField()
+    public function testGetTranslationsWithObjectField(): void
     {
         $modelName = 'Leads';
         $recordId = '00000000-0000-0000-0000-100000000001';
@@ -96,7 +96,7 @@ class TranslationsTableTest extends TestCase
         $this->assertEquals(2, count($result));
     }
 
-    public function testGetTranslationsAsEntity()
+    public function testGetTranslationsAsEntity(): void
     {
         $modelName = 'Leads';
         $recordId = '00000000-0000-0000-0000-100000000001';
@@ -112,7 +112,7 @@ class TranslationsTableTest extends TestCase
      *  testAddTranslation method
      * @return void
      */
-    public function testAddTranslation()
+    public function testAddTranslation(): void
     {
         $params = [
             'object_model' => 'Leads',
@@ -137,7 +137,7 @@ class TranslationsTableTest extends TestCase
      *  testGetLanguageId method
      * @return void
      */
-    public function testGetLanguageId()
+    public function testGetLanguageId(): void
     {
         $languageId = '00000000-0000-0000-0000-000000000001';
         $shortCode = 'ru';
@@ -149,7 +149,7 @@ class TranslationsTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->assertInstanceOf(TranslationsTable::class, new TranslationsTable);
     }
@@ -159,7 +159,7 @@ class TranslationsTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $validator = new Validator();
         $result = $this->Translations->validationDefault($validator);
@@ -172,7 +172,7 @@ class TranslationsTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildRules()
+    public function testBuildRules(): void
     {
         $rulesChecker = new RulesChecker();
         $result = $this->Translations->buildRules($rulesChecker);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,4 @@
 <?php
-// @codingStandardsIgnoreFile
-
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
@@ -9,29 +7,28 @@ if (empty($pluginName)) {
     throw new \RuntimeException("Plugin name is not configured");
 }
 
-$findRoot = function () {
-    $root = dirname(__DIR__);
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(__DIR__));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(dirname(__DIR__)));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
     throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
-define('ROOT', $findRoot());
+define('ROOT', $findRoot(__FILE__));
 define('APP_DIR', 'App');
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
@@ -108,9 +105,6 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
 Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
-
-Cake\Routing\DispatcherFactory::add('Routing');
-Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,7 +3,6 @@
 
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
-use Cake\Utility\Security;
 
 $pluginName = 'Translations';
 if (empty($pluginName)) {
@@ -58,7 +57,6 @@ Configure::write('App', [
     ]
 ]);
 Configure::write('debug', true);
-Security::salt('C14#E9YY0t*QZ2M9Ia4D6swLJ8507Kai47C14#E9YY0t*QZ2M9Ia4D6swLJ8507Kak38');
 
 $TMP = new Folder(TMP);
 $TMP->create(TMP . 'cache/models', 0777);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@ use Cake\Utility\Security;
 
 $pluginName = 'Translations';
 if (empty($pluginName)) {
-    throw new \Exception("Plugin name is not configured");
+    throw new \RuntimeException("Plugin name is not configured");
 }
 
 $findRoot = function () {
@@ -26,7 +26,7 @@ $findRoot = function () {
         return $root;
     }
 
-    throw new \Exception("Failed to find CakePHP");
+    throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
@@ -85,7 +85,7 @@ $cache = [
     ]
 ];
 
-Cake\Cache\Cache::config($cache);
+Cake\Cache\Cache::setConfig($cache);
 Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
@@ -95,13 +95,13 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::config('default', [
+Cake\Datasource\ConnectionManager::setConfig('default', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
 ]);
 
-Cake\Datasource\ConnectionManager::config('test', [
+Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -5,7 +5,4 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
-// Load all plugin routes. See the Plugin documentation on how to customize the loading of plugin routes.
-Plugin::routes();
-
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);


### PR DESCRIPTION
* Updated to [cakephp-plugin-template v5.2.0](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v5.2.0).
* Updated `composer.json`.
* Fixed all deprecated errors for CakePHP 3.6
* Fixed all PHPStan issues.
* Enabled PHPStan on TravisCI.