### PR TITLE
Clear PHPUnit output

### DIFF
--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -39,7 +39,8 @@ class TranslationsController extends AppController
                     'field' => !empty($params['object_field']) ? $params['object_field'] : '',
                 ]
             );
-            $this->response->withType('application/json')->withStringBody(json_encode($translations, JSON_UNESCAPED_UNICODE));
+            $body = (string)json_encode($translations, JSON_UNESCAPED_UNICODE);
+            $this->response->withType('application/json')->withStringBody($body);
             $this->autoRender = false;
         } else {
             $translations = $this->Translations->find('all')->contain('Languages');
@@ -122,7 +123,8 @@ class TranslationsController extends AppController
 
         $translation = $this->Translations->patchEntity($translation, $params);
         $result = $this->Translations->save($translation);
-        $this->response->withType('application/json')->withStringBody(json_encode(!empty($result) ? true : false));
+        $body = (string)json_encode(!empty($result) ? true : false);
+        $this->response->withType('application/json')->withStringBody($body);
         $this->autoRender = false;
     }
 

--- a/src/Controller/TranslationsController.php
+++ b/src/Controller/TranslationsController.php
@@ -39,9 +39,8 @@ class TranslationsController extends AppController
                     'field' => !empty($params['object_field']) ? $params['object_field'] : '',
                 ]
             );
-            $this->response->withType('application/json');
+            $this->response->withType('application/json')->withStringBody(json_encode($translations, JSON_UNESCAPED_UNICODE));
             $this->autoRender = false;
-            echo json_encode($translations, JSON_UNESCAPED_UNICODE);
         } else {
             $translations = $this->Translations->find('all')->contain('Languages');
             $this->set(compact('translations'));
@@ -123,9 +122,8 @@ class TranslationsController extends AppController
 
         $translation = $this->Translations->patchEntity($translation, $params);
         $result = $this->Translations->save($translation);
-        $this->response->withType('application/json');
+        $this->response->withType('application/json')->withStringBody(json_encode(!empty($result) ? true : false));
         $this->autoRender = false;
-        echo json_encode(!empty($result) ? true : false);
     }
 
     /**


### PR DESCRIPTION
Moves output into HTTP Response to avoid including the response into the PHPUnit output. Hence, the `echo` is being replaced by `Response::withStringBody`