### PR TITLE
Prevent afterSave in not new entities (task #16083)

### DIFF
--- a/src/Model/Table/TranslationsTable.php
+++ b/src/Model/Table/TranslationsTable.php
@@ -187,6 +187,11 @@ class TranslationsTable extends Table
      */
     public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
+        // No need to update the fields if the entity already exist.
+        if (!$entity->isNew()) {
+            return;
+        }
+
         if (empty($entity->get("language_id"))) {
             $entity->set('language_id', $this->getLanguageId($entity->get("locale")));
         }


### PR DESCRIPTION
Is not needed to update again the record to make it compatible with the plugin, plus the Translate CakePHP behavior when update the data doesn't carry in the entity the `locale` neither the `language_id` and the afterSave will fail.